### PR TITLE
Wait for MOTD before joining channels in irc bot

### DIFF
--- a/discirc/irc_bot.py
+++ b/discirc/irc_bot.py
@@ -74,6 +74,9 @@ class IRCBot(bottom.Client):
             self.send('PASS', password=self.password)
 
     def on_motddone(self, message):
+        """On MOTD received or no MOTD available event.
+        Clients should wait with issuing JOIN commands until either of these
+        messages are received."""
         for chan in self.channels.values():
             if chan not in self.channelPass:
                 self.send('JOIN', channel=chan)

--- a/discirc/irc_bot.py
+++ b/discirc/irc_bot.py
@@ -73,10 +73,8 @@ class IRCBot(bottom.Client):
         if self.password:
             self.send('PASS', password=self.password)
 
+     """checking if Message Of The Day is done because it may interfere with joining channels"""
     def on_motddone(self, message):
-        """On MOTD received or no MOTD available event. MOTD stands for Message Of The Day, as per RFC 1459.
-        Clients should wait with issuing JOIN commands until either of these
-        messages are received."""
         for chan in self.channels.values():
             if chan not in self.channelPass:
                 self.send('JOIN', channel=chan)

--- a/discirc/irc_bot.py
+++ b/discirc/irc_bot.py
@@ -74,7 +74,7 @@ class IRCBot(bottom.Client):
             self.send('PASS', password=self.password)
 
     def on_motddone(self, message):
-        """On MOTD received or no MOTD available event.
+        """On MOTD received or no MOTD available event. MOTD stands for Message Of The Day, as per RFC 1459.
         Clients should wait with issuing JOIN commands until either of these
         messages are received."""
         for chan in self.channels.values():

--- a/discirc/irc_bot.py
+++ b/discirc/irc_bot.py
@@ -56,6 +56,8 @@ class IRCBot(bottom.Client):
         self.on('CLIENT_CONNECT', self.on_connect)
         self.on('PING', self.on_ping)
         self.on('PRIVMSG', self.on_irc_message)
+        self.on('RPL_ENDOFMOTD', self.on_motddone)
+        self.on('ERR_NOMOTD', self.on_motddone)
 
         self.users = dict()
 
@@ -70,6 +72,8 @@ class IRCBot(bottom.Client):
         self.send('USER', user=self.nick, realname='Discord gateway')
         if self.password:
             self.send('PASS', password=self.password)
+
+    def on_motddone(self, message):
         for chan in self.channels.values():
             if chan not in self.channelPass:
                 self.send('JOIN', channel=chan)

--- a/discirc/irc_bot.py
+++ b/discirc/irc_bot.py
@@ -73,8 +73,8 @@ class IRCBot(bottom.Client):
         if self.password:
             self.send('PASS', password=self.password)
 
-     """checking if Message Of The Day is done because it may interfere with joining channels"""
     def on_motddone(self, message):
+        """checking if Message Of The Day is done because it may interfere with joining channels"""
         for chan in self.channels.values():
             if chan not in self.channelPass:
                 self.send('JOIN', channel=chan)


### PR DESCRIPTION
Hello,

your version does not work for the MOTD message, so on some IRC servers it fails to join any channels.

I fixed this by adding a callback for this, I hope you can merge it.

Thanks,
Tamas