### PR TITLE
Split discord messages into chunks for IRC

### DIFF
--- a/discirc/irc_bot.py
+++ b/discirc/irc_bot.py
@@ -23,6 +23,7 @@
 
 import bottom
 import random
+import textwrap
 import discirc.signals as SIGNALNAMES
 
 from asyncblink import signal
@@ -41,6 +42,9 @@ class IRCBot(bottom.Client):
 
     COLOR_PREF = '\x03'
     CANCEL = '\u000F'
+    # chunck length in letters - actual limit is 512 bytes
+    # set to 256 to anticipate some Unicode chars in the content
+    IRC_MSG_CHUNK_LENGTH = 256
 
     def __init__(self, config):
         super(IRCBot, self).__init__(
@@ -131,4 +135,6 @@ class IRCBot(bottom.Client):
                 self.CANCEL,
                 msg
             )
-            self.send('PRIVMSG', target=target, message=format_msg)
+            chunks = textwrap.wrap(format_msg, self.IRC_MSG_CHUNK_LENGTH, break_long_words=False)
+            for chunk in chunks:
+                self.send('PRIVMSG', target=target, message=chunk)


### PR DESCRIPTION
Hello,

I noticed that sometimes Discord messages would get silently lost and not transmitted to IRC for some reason. I traced the problem to the IRC message length limit - this would happen when the IRC PRIVMSG content was over 512 bytes.

To fix this I added a new field to the irc bot that would specify the chunk length in letters, and then in on_discord_message I used textwrap (from the Python standard library) to break the message into pieces and transmit that over to IRC - I used this method since it is Unicode aware and can avoid breaking words which is nice.

This seems to work very well and we are no longer losing messages. Let me know if you'd like any changes to the commit.